### PR TITLE
Missing semicolon

### DIFF
--- a/js/sb-admin-2.js
+++ b/js/sb-admin-2.js
@@ -25,4 +25,4 @@ $(function() {
             $("#page-wrapper").css("min-height", (height) + "px");
         }
     })
-})
+});


### PR DESCRIPTION
Without this semicolon, when the JS code is concatened with another JS code (for example, when using ngbp) this causes an error.
