### PR TITLE
All local variables must be prepended with `var`

### DIFF
--- a/dist/js/sb-admin-2.js
+++ b/dist/js/sb-admin-2.js
@@ -9,8 +9,8 @@ $(function() {
 // Sets the min-height of #page-wrapper to window size
 $(function() {
     $(window).bind("load resize", function() {
-        topOffset = 50;
-        width = (this.window.innerWidth > 0) ? this.window.innerWidth : this.screen.width;
+        var topOffset = 50;
+        var width = (this.window.innerWidth > 0) ? this.window.innerWidth : this.screen.width;
         if (width < 768) {
             $('div.navbar-collapse').addClass('collapse');
             topOffset = 100; // 2-row-menu
@@ -18,7 +18,7 @@ $(function() {
             $('div.navbar-collapse').removeClass('collapse');
         }
 
-        height = ((this.window.innerHeight > 0) ? this.window.innerHeight : this.screen.height) - 1;
+        var height = ((this.window.innerHeight > 0) ? this.window.innerHeight : this.screen.height) - 1;
         height = height - topOffset;
         if (height < 1) height = 1;
         if (height > topOffset) {


### PR DESCRIPTION
Otherwise it causes problems in `'use strict';` mode