### PR TITLE
Made bower.json->license compatible with bower.json-spec

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -10,7 +10,7 @@
     "bootstrap",
     "theme"
   ],
-  "license": "Apache",
+  "license": "Apache-2.0",
   "ignore": [
     "**/.*",
     "node_modules",


### PR DESCRIPTION
(https://github.com/bower/bower.json-spec, using a SPDX license identifier)

I did this because http://www.webjars.org/bower requires a valid license identifier