### PR TITLE
Remove moot `version` property from bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,5 @@
 {
   "name": "startbootstrap-sb-admin-2",
-  "version": "1.0.7",
   "homepage": "http://startbootstrap.com/template-overviews/sb-admin-2/",
   "authors": [
     "David Miller"


### PR DESCRIPTION
Per bower/bower.json-spec@a325da3

Also their maintainer says they probably won't ever use it: http://stackoverflow.com/questions/24844901/bowers-bower-json-file-version-property