### PR TITLE
remove wrong checking of active link in sidebar

### DIFF
--- a/dist/js/sb-admin-2.js
+++ b/dist/js/sb-admin-2.js
@@ -28,7 +28,7 @@ $(function() {
 
     var url = window.location;
     var element = $('ul.nav a').filter(function() {
-        return this.href == url || url.href.indexOf(this.href) == 0;
+        return this.href == url;
     }).addClass('active').parent().parent().addClass('in').parent();
     if (element.is('li')) {
         element.addClass('active');


### PR DESCRIPTION
`url.href.indexOf(this.href) == 0` is not a good way for checking which link is active.

Example:

I have a page foo.com, for which `Dashboard` link in the sidebar is active. And `Users` link is inactive. When I go to foo.com/users, `Dashboard` should not be active, and `Users` should be active. However, this is not true - both are active. `Dashboard` is active, because of the aforementioned condition.
`url.href` is foo.com/users and `indexOf` foo.com is indeed `0`, which is why `Dashboard` is wrongly active.