### PR TITLE
Using bower it's impossible to use own variables

### DIFF
--- a/less/sb-admin-2.less
+++ b/less/sb-admin-2.less
@@ -1,0 +1,3 @@
+@import "variables.less";
+@import "mixins.less";
+@import "sb-admin-styles.less";

--- a/less/sb-admin-styles.less
+++ b/less/sb-admin-styles.less
@@ -1,6 +1,3 @@
-@import "variables.less";
-@import "mixins.less";
-
 // Global Styles
 
 body {


### PR DESCRIPTION
We're using bower to manage our dependencies in our massive app, and have a slightly different bootstrap theme/variables set we wish to apply. Unfortunately in SBAdmin2's current state, our variables get completely ignored as building `sb-admin-2.less` automatically pulls in it's own `variables.less`.

This PR splits out the admin styles into a separate `.less` file that can then be included instead of `sb-admin-2.less`. This should not break anything as `sb-admin-2.less` still pulls in these styles (`sb-admin-styles.less`), but it enables alternative variables to be defined and then used.