### PR TITLE
Fix responsive datatable example and prevent from 404

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -34,7 +34,7 @@
     "holderjs": "~2.4.1",
     "metisMenu": "~1.1.3",
     "morrisjs": "~0.5.1",
-    "datatables-responsive": "~1.0.3",
+    "datatables-responsive": "1.0.6",
     "bootstrap-social": "~4.8.0",
     "flot.tooltip": "~0.8.4"
   }

--- a/pages/tables.html
+++ b/pages/tables.html
@@ -390,7 +390,7 @@
                         <!-- /.panel-heading -->
                         <div class="panel-body">
                             <div class="dataTable_wrapper">
-                                <table class="table table-striped table-bordered table-hover" id="dataTables-example">
+                                <table width="100%" class="table table-striped table-bordered table-hover" id="dataTables-example">
                                     <thead>
                                         <tr>
                                             <th>Rendering engine</th>
@@ -1127,7 +1127,8 @@
     <!-- DataTables JavaScript -->
     <script src="../bower_components/datatables/media/js/jquery.dataTables.min.js"></script>
     <script src="../bower_components/datatables-plugins/integration/bootstrap/3/dataTables.bootstrap.min.js"></script>
-
+    <script src="../bower_components/datatables-responsive/js/dataTables.responsive.js"></script>
+    
     <!-- Custom Theme JavaScript -->
     <script src="../dist/js/sb-admin-2.js"></script>
 


### PR DESCRIPTION
Target of this patch:
- Missing responsive script,
- Missing css style for responsive mode
- Unfortunately patch version 1.0.7 of datatables-responsive library breaks backward compatibility - there is no css in distribution and they are renamed.