### PR TITLE
Fix open & select right sidebar item on load page

### DIFF
--- a/dist/js/sb-admin-2.js
+++ b/dist/js/sb-admin-2.js
@@ -26,11 +26,11 @@ $(function() {
         }
     });
 
-    var url = window.location;
-    var element = $('ul.nav a').filter(function() {
-        return this.href == url;
-    }).addClass('active').parent().parent().addClass('in').parent();
-    if (element.is('li')) {
-        element.addClass('active');
-    }
+	// current item is set "active"
+	var currentItem = $('ul.nav a').filter(function () {
+		return this.href == window.location;
+	}).addClass('active');
+	// all ul containing active item are set "collapse in" and
+	// all parent li are set "active"
+	$('#side-menu ul.nav').has(currentItem).addClass('in').parent().addClass('active');
 });

--- a/dist/js/sb-admin-2.js
+++ b/dist/js/sb-admin-2.js
@@ -26,11 +26,48 @@ $(function() {
         }
     });
 
-	// current item is set "active"
-	var currentItem = $('ul.nav a').filter(function () {
-		return this.href == window.location;
-	}).addClass('active');
-	// all ul containing active item are set "collapse in" and
-	// all parent li are set "active"
-	$('#side-menu ul.nav').has(currentItem).addClass('in').parent().addClass('active');
+	/* current item is set "active" */
+	activeCurrentItem();
+
+	/*
+	 instead more .filter() calls it used only one .each() iteration.
+	 Pathname is used to purge: protocol, host, port, search and hash.
+	 */
+	function activeCurrentItem() {
+		var windowPathname = window.location.pathname;
+		var windowSearch = window.location.search;
+		var currentItem = document.createElement('a');
+
+		$('ul.nav a')
+			.each(function (index, item) {
+				var matchSearch = $(item).data('search');
+				var windowLink = windowPathname;
+				var itemLink = item.pathname;
+				var currentLink = currentItem.pathname;
+
+				// skip href="#"
+				if (this.href.slice(-1) !== '#') {
+					if (matchSearch) {
+						// add search to pathname
+						windowLink += windowSearch;
+						itemLink += item.search;
+						currentLink += currentItem.search;
+					}
+
+					if (itemLink === windowLink) {
+						// equal match founded, got it and stopped iteration
+						currentItem = item;
+						return false;
+					} else if (windowLink.indexOf(itemLink) === 0 && itemLink.length > currentLink.length) {
+						// window location href start with same link href, i get longer pathname to match
+						currentItem = item;
+					}
+				}
+			});
+
+		if (currentItem.pathname.length) {
+			currentItem = $(currentItem).addClass('active');
+			$('#side-menu ul.nav').has(currentItem).addClass('in').parent().addClass('active');
+		}
+	}
 });


### PR DESCRIPTION
When third level item is selected sidebar was not expanded because "ul.nav-second-level" does not have *in* class.

I fixed it setting *active* on current "ul.nav a" and then setting *in* on "ul.nav" parents and *active* on "li" parents of "ul.nav".

This should also fix #61