### PR TITLE
Remove deprecated bower.json option: version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,5 @@
 {
   "name": "startbootstrap-sb-admin-2",
-  "version": "1.0.9",
   "homepage": "http://startbootstrap.com/template-overviews/sb-admin-2/",
   "authors": [
     "David Miller"


### PR DESCRIPTION
`version` option for `bower.json` it's deprecated and ignored by bower, as you can read in *`bower.json` specification*:

> https://github.com/bower/spec/blob/master/json.md#version
  Use git or svn tags instead. This field is ignored by Bower.
