### PR TITLE
Add window resize trigger

### DIFF
--- a/js/sb-admin-2.js
+++ b/js/sb-admin-2.js
@@ -39,4 +39,6 @@ $(function() {
             break;
         }
     }
+    
+    $(window).trigger('resize');
 });


### PR DESCRIPTION
The div #page-wrapper does not resize on page load if the content is less than the size of the screen (this behavior can be seen on Sample pages > Blank Page). The trigger ensures the event listener is executed.