### PR TITLE
Hide navigation menu in mobile

### DIFF
--- a/js/sb-admin-2.js
+++ b/js/sb-admin-2.js
@@ -15,6 +15,13 @@
     if ($(window).width() < 768) {
       $('.sidebar .collapse').collapse('hide');
     };
+    
+    // Toggle the side navigation when window is resized below 480px
+    if ($(window).width() < 480 && !$(".sidebar").hasClass("toggled")) {
+      $("body").addClass("sidebar-toggled");
+      $(".sidebar").addClass("toggled");
+      $('.sidebar .collapse').collapse('hide');
+    };
   });
 
   // Prevent the content wrapper from scrolling when the fixed side navigation hovered over


### PR DESCRIPTION
In the mobile with the menu open, the page itself is too narrow. Therefore, I propose to close the navigation menu. Intuitively, it opens due to the presence of a burger. And closing does not look so intuitive as in most other sites and applications the navigation menu is initially hidden