### PR TITLE
Fixed build error: Replace Autoprefixer browsers option to Browserslist config

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -91,7 +91,7 @@ function css() {
     }))
     .on("error", sass.logError)
     .pipe(autoprefixer({
-      browsers: ['last 2 versions'],
+      overrideBrowserslist: ['last 2 versions'],
       cascade: false
     }))
     .pipe(header(banner, {


### PR DESCRIPTION
When I run `npm start`, I get the following error during the build process:

```
Replace Autoprefixer browsers option to Browserslist config.
  Use browserslist key in package.json or .browserslistrc file.
```
**Reason**: 'browsers' key of Autoprefixer is deprecated. This pull request should be able to fix it.

See https://github.com/gatsbyjs/gatsby/pull/14533#issue-284959517, and https://www.npmjs.com/package/browserslist