### PR TITLE
Update labeling of light button

### DIFF
--- a/buttons.html
+++ b/buttons.html
@@ -475,7 +475,7 @@
                     <span class="icon text-gray-600">
                       <i class="fas fa-arrow-right"></i>
                     </span>
-                    <span class="text">Split Button Primary</span>
+                    <span class="text">Split Button Light</span>
                   </a>
                   <div class="mb-4"></div>
                   <p>Also works with small and large button classes!</p>


### PR DESCRIPTION
Update labeling of light split button. Text is "Split Button **Primary**", but should be "Split Button **Light**".