### PR TITLE
Comment Typo Fix

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
                 Interface
             </div>
 
-            <!-- Nav Item - Pages Collapse Menu -->
+            <!-- Nav Item - Components Collapse Menu -->
             <li class="nav-item">
                 <a class="nav-link collapsed" href="#" data-toggle="collapse" data-target="#collapseTwo"
                     aria-expanded="true" aria-controls="collapseTwo">


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/5012f6cd-37d3-400b-9d7f-048294052371)

As per the above image, the comment "Nav Item - Pages Collapse Menu" was changed to "Nav Item - Components Collapse Menu" as this sections is for the Components collapse section rather than the pages collapse section.