### PR TITLE
Change resize event handler to use 'on' method

### DIFF
--- a/js/sb-admin-2.js
+++ b/js/sb-admin-2.js
@@ -11,7 +11,7 @@
   });
 
   // Close any open menu accordions when window is resized below 768px
-  $(window).resize(function() {
+  $(window).on('resize',function() {
     if ($(window).width() < 768) {
       $('.sidebar .collapse').collapse('hide');
     };


### PR DESCRIPTION
Change resize event handler to use 'on' method, as jQuery.fn.resize() event shorthand is deprecated